### PR TITLE
Fix #8, prepending data_root path twice when loading image

### DIFF
--- a/diode.py
+++ b/diode.py
@@ -112,7 +112,7 @@ class DIODE(Dataset):
         de_fname = osp.join(self.data_root, '{}_depth.npy'.format(im))
         de_mask_fname = osp.join(self.data_root, '{}_depth_mask.npy'.format(im))
 
-        im = np.array(Image.open(osp.join(self.data_root, im_fname)))
+        im = np.array(Image.open(im_fname))
         de = np.load(de_fname).squeeze()
         de_mask = np.load(de_mask_fname)
         return im, de, de_mask


### PR DESCRIPTION
I believe that this `osp.join()` is a bug as `im_fname` already contains `self.data_root` prefix from [line 111](https://github.com/diode-dataset/diode-devkit/blob/master/diode.py#L111)